### PR TITLE
FIX: nonlocal n variable

### DIFF
--- a/matlab_octave/picard_standard.m
+++ b/matlab_octave/picard_standard.m
@@ -68,7 +68,7 @@ y_list = {};
 r_list = {};
 current_loss = loss(Y, W);
 
-for n =1:maxiter
+for n_top = 1:maxiter
     % Compute the score function
     thY = tanh(Y / 2.);
     % Compute the relative gradient
@@ -79,7 +79,7 @@ for n =1:maxiter
         break
     end
     % Update the memory
-    if n > 1
+    if n_top > 1
         s_list{end + 1} = direction;
         y = G - G_old;
         y_list{end + 1} = y;
@@ -106,7 +106,7 @@ for n =1:maxiter
     W = new_W;
     current_loss = new_loss;
     if verbose
-        fprintf('iteration %d, gradient norm = %.4g\n', n + 1, G_norm)
+        fprintf('iteration %d, gradient norm = %.4g\n', n_top, G_norm)
     end
 end
 
@@ -142,7 +142,7 @@ function [converged, Y_new, W_new, new_loss, rel_step] = line_search(Y, W, direc
         alpha = alpha / 2.;
     end
     if verbose
-        sprintf('line search failed, falling back to gradient');
+        fprintf('line search failed, falling back to gradient.\n');
     end
     converged = false;
     rel_step = alpha * direction;


### PR DESCRIPTION
I was investigating why the progress reported by matlab version of picard is so weird:
```
iteration 1.986980e-09, gradient norm = 1.509e-09
iteration 2.619655e-09, gradient norm = 1.653e-09
iteration 5.950396e-09, gradient norm = iteration 51, gradient norm = 3.241e-09
iteration 2.305300e-09, gradient norm = 3.546e-09
iteration 1.689771e-09, gradient norm = 7.261e-10
iteration 2.198824e-09, gradient norm = 1.123e-09
```
when I found out that because you use `n` iter variable in the `picard_standard` function and its nested functions the state of `n` is shared across all these functions. I highly doubt that was intentional - but rather a unexpected result of how matlab handles nested functions.
This small PR renames top level `n` to `n_top` so that its state is not changed by its nested functions.