### PR TITLE
FIX: fix printing of progress

### DIFF
--- a/matlab_octave/picard_standard.m
+++ b/matlab_octave/picard_standard.m
@@ -74,7 +74,7 @@ for n_top = 1:maxiter
     % Compute the relative gradient
     G = (thY * Y') / T - eye(N);
     % Stopping criterion
-    G_norm = max(abs(G));
+    G_norm = max(max(abs(G)));
     if G_norm < tol
         break
     end

--- a/matlab_octave/picardo.m
+++ b/matlab_octave/picardo.m
@@ -87,7 +87,7 @@ for n=1:maxiter
     % Project
     G = (g - g') / 2.;
     % Stopping criterion
-    gradient_norm = max(abs(G));
+    gradient_norm = max(max(abs(G)));
     if gradient_norm < tol
         break
     end


### PR DESCRIPTION
I've fixed the printing bug I reported in the last PR.
This change does not influence the behavior only the progress-printing.
`max(abs(G))` is a vector, because `max` operates along first non-singleton dimension by default. It satisfies `if G_norm < tol` when all entries are below tol so exactly when `max(max(abs(G)))` does, but the latter is just one value so it works well in printing.