### PR TITLE
Adds pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[build-system]
-requires = ["setuptools>=42", "wheel", "numpy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "numpy"]

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
           platforms='any',
           python_requires='>=3.6',
           install_requires=[
-              'numpy'
+              'numpy',
               'numexpr',
           ],
           packages=package_tree('picard'),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@
 
 import os
 import setuptools  # noqa; we are using a setuptools namespace
-from numpy.distutils.core import setup
+from setuptools import setup
+
 
 descr = """Preconditoned ICA for Real Data"""
 
@@ -62,6 +63,7 @@ if __name__ == "__main__":
           platforms='any',
           python_requires='>=3.6',
           install_requires=[
+              'numpy'
               'numexpr',
           ],
           packages=package_tree('picard'),


### PR DESCRIPTION
Because numpy is imported within setup.py, installation will fail in
environments in which numpy was not installed in advance of an attempt to
install picard.

This change makes the project compliant with
[PEP518](https://www.python.org/dev/peps/pep-0518/) and removes the
requirement that numpy be separately installed in advance into the
environment into which "picard" is installed.