### PR TITLE
Maintenance update

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [3.7, 3.8, 3.9]
+        python: [3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -5,3 +5,4 @@ scikit-learn >=0.18
 sphinx-bootstrap-theme
 sphinx-gallery
 pooch
+tqdm

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -4,3 +4,4 @@ pillow
 scikit-learn >=0.18
 sphinx-bootstrap-theme
 sphinx-gallery
+pooch


### PR DESCRIPTION
This removes python 3.7 support in the unit tests, and adds a dependency in the doc now needed by mne to download datasets.