### PR TITLE
fix matlab pca warning (fix #49)

### DIFF
--- a/matlab_octave/picard.m
+++ b/matlab_octave/picard.m
@@ -155,7 +155,7 @@ end
 
 if n_components > getrank(X),
     warning(['Input matrix is of deficient rank. ' ...
-            'Please consider to reduce dimensionality (pca) prior to ICA.'])
+            'Please consider reducing the dimensionality (e.g. with PCA) prior to ICA.'])
 end
 
 if centering,

--- a/matlab_octave/picard.m
+++ b/matlab_octave/picard.m
@@ -153,7 +153,7 @@ if whiten == false && n_components ~= size(X, 1),
     error('PCA works only if whiten=true')
 end
 
-if n_components ~= getrank(X),
+if n_components >= getrank(X),
     warning(['Input matrix is of deficient rank. ' ...
             'Please consider to reduce dimensionality (pca) prior to ICA.'])
 end

--- a/matlab_octave/picard.m
+++ b/matlab_octave/picard.m
@@ -153,7 +153,7 @@ if whiten == false && n_components ~= size(X, 1),
     error('PCA works only if whiten=true')
 end
 
-if n_components >= getrank(X),
+if n_components > getrank(X),
     warning(['Input matrix is of deficient rank. ' ...
             'Please consider to reduce dimensionality (pca) prior to ICA.'])
 end


### PR DESCRIPTION
this fixes a warning raised in matlab when calling for a number of components that is smaller than the rank of the data